### PR TITLE
Fix NegaMaxAgent bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.version>5.6.0</junit.version>
+    <junit.version>5.8.2</junit.version>
+    <mockito.version>5.5.0</mockito.version>
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
@@ -23,6 +24,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/jherrick/BasicBoardEvaluator.java
+++ b/src/main/java/com/jherrick/BasicBoardEvaluator.java
@@ -27,10 +27,10 @@ public class BasicBoardEvaluator implements BoardEvaluator {
         // Find board that is won - This is the most extreme case (will always or never
         // be picked)
         if (board.getBoardState() == BoardState.X_WON) {
-            return Integer.MAX_VALUE;
+            return Integer.MAX_VALUE-1;
         }
         if (board.getBoardState() == BoardState.O_WON) {
-            return Integer.MIN_VALUE;
+            return Integer.MIN_VALUE+1;
         }
 
         return evaluateBoard(board);

--- a/src/main/java/com/jherrick/BigBoard.java
+++ b/src/main/java/com/jherrick/BigBoard.java
@@ -101,8 +101,7 @@ public class BigBoard implements Board {
         subboard.makeMove(m.move, side);
 
 		updateStateBitboards(m.board);
-		isWon();
-		isDrawn();
+        gameStatusCheck();
 		toggleSide();
 		putMoveInLog(m);
 	}
@@ -201,37 +200,26 @@ public class BigBoard implements Board {
     public void takeMove(Move m) {
         boards[m.board].takeMove(m.move);
         updateStateBitboards(m.board);
+        gameStatusCheck();
         toggleSide();
         count--;
         pastMoves[count] = null;
     }
 
     /**
-     * Returns true if a player has won on the board TODO: this check only needs to
-     * be done after many, many moves TODO: almost identical to SubBoard function.
-     * Hmmm... inheritance? TODO: Hash Map!
-     **/
-    public void isWon() {
+     * Update the game status to X_WON, O_WON, DRAWN, or IN_PROGRESS.
+     * TODO: this is currently dependent on updateBitBoards being called before it. Roll the calls together so there's no required order of operations
+     */
+    public void gameStatusCheck(){
         if (hasXWon()) {
-            if (state == BoardState.IN_PROGRESS) {
-                state = BoardState.X_WON;
-            }
+            state = BoardState.X_WON;
         } else if (hasOWon()) {
-            if (state == BoardState.IN_PROGRESS) {
-                state = BoardState.O_WON;
-            }
+            state = BoardState.O_WON;
+        } else if (hasDrawn()) {
+            state = BoardState.DRAWN;
         }
-    }
-
-    /**
-     * Returns true if the the board is drawn (no available moves) TODO: this check
-     * only needs to be done after many, many moves
-     **/
-    public void isDrawn() {
-        if (hasDrawn()) {
-            if (state == BoardState.IN_PROGRESS) {
-                state = BoardState.DRAWN;
-            }
+        else{
+            state = BoardState.IN_PROGRESS;
         }
     }
 

--- a/src/main/java/com/jherrick/MoveAndValue.java
+++ b/src/main/java/com/jherrick/MoveAndValue.java
@@ -10,6 +10,6 @@ public class MoveAndValue implements Comparable<MoveAndValue> {
 	}
 
 	public int compareTo(MoveAndValue y) {
-		return this.value - y.value;
+		return Integer.compare(this.value, y.value);
 	}
 }

--- a/src/main/java/com/jherrick/NegaMaxAgent.java
+++ b/src/main/java/com/jherrick/NegaMaxAgent.java
@@ -5,25 +5,24 @@ import java.util.Arrays;
 
 public class NegaMaxAgent implements Agent {
 	private final BoardEvaluator evaluator;
-	private final Side side; // TODO: right now, the negamax can only play as X. This needs to be generalized
+	private final Side agentSide; // the side that the agent is playing // TODO: right now, the negamax can only play as X. This needs to be generalized
 
-	public NegaMaxAgent(BoardEvaluator evaluator, Side side) {
+	public NegaMaxAgent(BoardEvaluator evaluator, Side agentSide) {
 		this.evaluator = evaluator;
-		this.side = side;
+		this.agentSide = agentSide;
 	}
 
 	@Override
-	public Move pickMove(Board game) {
-		// Create copy of board to simulate
-		BigBoard tempGame = new BigBoard(game.getBoardPosition(), game.getSideForNextMove(), game.getLastMove());
+	public Move pickMove(Board gameBoard) {
+		// Create a copy of board to safely simulate moves
+		BigBoard simulationBoard = new BigBoard(gameBoard.getBoardPosition(), gameBoard.getSideForNextMove(), gameBoard.getLastMove());
 		
-		int depth = 0;
-		int beta = Integer.MAX_VALUE;
+		int beta = Integer.MAX_VALUE-1;
 		int color = 1;
-		int depthCount = 1;
-		int maxValue = Integer.MIN_VALUE;
+		int iterativeMaxDepth = 1; // the temporary max depth count used by the iterative deepening algorithm. Counts up from 1 to maxDepth
+		int maxDepth= 5; // the absolute maximum depth that negamax will evaluate to
 		// iterative deepening
-		List<Move> tempMoves = (List<Move>) tempGame.getLegalMoves();
+		List<Move> tempMoves = simulationBoard.getLegalMoves();
 
 		MoveAndValue[] moves = new MoveAndValue[tempMoves.size()];
 		int count = 0;
@@ -33,16 +32,19 @@ public class NegaMaxAgent implements Agent {
 			count++;
 		}
 
-		while (depthCount <= 5) {
+		while (iterativeMaxDepth <= maxDepth) {
+			// reset the max value between rounds. If we see a great move at depth 1 that turns into a terrible move later,
+			// we don't want to keep thinking we have an amazing move available
+			int maxValue = Integer.MIN_VALUE+1;
 			for (int i = 0; i < moves.length; i++) {
-				tempGame.makeMove(moves[i].move);
+				simulationBoard.makeMove(moves[i].move);
 
 				/*
 				 * maxValue here starts off as -infinity. In a normal negamax, the root has a
 				 * value after the first branch explored that acts as a lower bound for the rest
 				 * of the search. Essentially it acts as the root's alpha.
 				 */
-				moves[i].value = negaMax(tempGame, depth, depthCount, maxValue, beta, color);
+				moves[i].value = -negaMax(simulationBoard,  1, iterativeMaxDepth, -beta, -maxValue, -color);
 
 				// This should take care of the fact that we are doing each of the root's moves
 				// separately. This takes the place of the "max" in the recursive negamax
@@ -50,27 +52,46 @@ public class NegaMaxAgent implements Agent {
 				if (moves[i].value > maxValue) {
 					maxValue = moves[i].value;
 				}
-				tempGame.undoLastMove();
+				simulationBoard.undoLastMove();
 
 			}
-			depthCount++;
+			iterativeMaxDepth++;
 			// explore the best moves first
 			Arrays.sort(moves);
 		}
 
-		return moves[0].move;
+//		return moves[0].move;
+		return pickRandomBestMove(moves);
+	}
+
+	// If a number of moves are tied with the highest score, pick a random one so that the bot varies its play
+	// TODO: this will lead to the behavior that if the CPU has a guaranteed win, it will make random moves instead of immediately winning.
+	// 	Should be fine functionally, but might be annoying to play against. Do we need to implement some discounting?
+	private Move pickRandomBestMove(MoveAndValue[] scoredMoves){
+		Arrays.sort(scoredMoves);
+		int bestScore = scoredMoves[0].value;
+
+		// count the number of moves tied for top score
+		int numMovesWithHighScore = 1;
+		while(numMovesWithHighScore < scoredMoves.length && bestScore == scoredMoves[numMovesWithHighScore].value){
+			numMovesWithHighScore++;
+		}
+
+		// pick a random move from the moves tied for the highest score
+		int randomHighScoringMoveIndex = (int) Math.floor(Math.random() * (double) numMovesWithHighScore);
+		return scoredMoves[randomHighScoringMoveIndex].move;
 	}
 
 	// color keeps track of the player. It is 1 if we are the player, -1 if the
 	// opponent is the player
-	private int negaMax(Board temp_game, int depth, int depthCount, int alpha, int beta, int color) {
+	private int negaMax(Board simulationBoard, int currentDepth, int depthCount, int alpha, int beta, int color) {
 
 		// if we are at the end of the game or have reached the iterative deepening
 		// depth, evaluate the state of the board and return a reward
-		// Note: Maybe factor depth into the evaluation in the future?
-		if (temp_game.getBoardState() == BoardState.X_WON || temp_game.getBoardState() == BoardState.O_WON
-				|| depth == depthCount) {
-			return (int) (color * evaluator.evaluate(temp_game, side));
+		// Note: Maybe factor depth into the evaluation in the future? Ie if we can win now, why win later?
+		if (simulationBoard.getBoardState() == BoardState.X_WON || simulationBoard.getBoardState() == BoardState.O_WON
+				|| currentDepth == depthCount) {
+			return (int) (color * evaluator.evaluate(simulationBoard, agentSide));
 		}
 
 		// keeps track of the value of the best move we've found so far. Starts at
@@ -78,15 +99,15 @@ public class NegaMaxAgent implements Agent {
 		int max = Integer.MIN_VALUE;
 
 		// explores each node in the tree
-		for (Move possibleMove : temp_game.getLegalMoves()) {
+		for (Move possibleMove : simulationBoard.getLegalMoves()) {
 
 			// these three lines make a move, recurivsely call the negamax on the new board
 			// state, and then un-make the move. This allows us to get the value of the move
 			// without
 			// "making" the move on our actual board
-			temp_game.makeMove(possibleMove);
-			int negaMax_value = -negaMax(temp_game, depth + 1, depthCount, -beta, -alpha, -color);
-			temp_game.undoLastMove();
+			simulationBoard.makeMove(possibleMove);
+			int negaMax_value = -negaMax(simulationBoard, currentDepth + 1, depthCount, -beta, -alpha, -color);
+			simulationBoard.undoLastMove();
 
 			// if we found a move better than our max, it is our new max
 			if (negaMax_value > max) {
@@ -100,8 +121,8 @@ public class NegaMaxAgent implements Agent {
 
 			// if the move we are looking at has a value greater than the worst move the
 			// opponent can make us take, we prune
-			if (negaMax_value >= beta) {
-				return beta;
+			if (negaMax_value > beta) {
+				return negaMax_value; // TODO: I think this is the right value to retun here, but I'm not positive. Need to double check what we should return during pruning.
 			}
 
 		}

--- a/src/main/java/com/jherrick/NegaMaxAgent.java
+++ b/src/main/java/com/jherrick/NegaMaxAgent.java
@@ -8,13 +8,27 @@ public class NegaMaxAgent implements Agent {
 	private final BoardEvaluator evaluator;
 	private final Side agentSide; // the side that the agent is playing // TODO: right now, the negamax can only play as X. This needs to be generalized
 
+	// How long the agent is allowed to think, in milliseconds. If the value is negative, it has no limit
+	private long thinkTimeMs = -1L;
+
+	// When the agent has to finish analyzing the current move. If it's negative, it can think forever
+	private long timeLimit = -1L;
+
 	public NegaMaxAgent(BoardEvaluator evaluator, Side agentSide) {
 		this.evaluator = evaluator;
 		this.agentSide = agentSide;
+
+	}
+	public NegaMaxAgent(BoardEvaluator evaluator, Side agentSide, Long thinkTimeMs) {
+		this.evaluator = evaluator;
+		this.agentSide = agentSide;
+		this.thinkTimeMs = thinkTimeMs;
 	}
 
 	@Override
 	public Move pickMove(Board gameBoard) {
+		// Calculate when the Agent has to return a selected move
+		setTimeout();
 		// Create a copy of board to safely simulate moves
 		BigBoard simulationBoard = new BigBoard(gameBoard.getBoardPosition(), gameBoard.getSideForNextMove(), gameBoard.getLastMove());
 		
@@ -48,39 +62,25 @@ public class NegaMaxAgent implements Agent {
 				moves[i].value = -negaMax(simulationBoard,  1, iterativeMaxDepth, -beta, -maxValue, -color);
 
 				// This should take care of the fact that we are doing each of the root's moves
-				// separately. This takes the place of the "max" in the recursive negamax
-				// function
+				// separately. This takes the place of the "max" in the recursive negamax function
 				if (moves[i].value > maxValue) {
 					maxValue = moves[i].value;
 				}
 				simulationBoard.undoLastMove();
 
+				// Check if the Agent has more time to think. If it does not, return the best move it has found so far
+				if(atTimeout()){
+					// Since our scores won't be consistent if we're mid-layer, return the best move from the last layer we completed
+					return bestMoveSoFar(moves);
+				}
+
 			}
 			iterativeMaxDepth++;
-			// explore the best moves first
+			// Keep track of the best moves we've seen so far and explore the best moves first
 			Arrays.sort(moves, Collections.reverseOrder());
 		}
 
-//		return moves[0].move;
 		return pickRandomBestMove(moves);
-	}
-
-	// If a number of moves are tied with the highest score, pick a random one so that the bot varies its play
-	// TODO: this will lead to the behavior that if the CPU has a guaranteed win, it will make random moves instead of immediately winning.
-	// 	Should be fine functionally, but might be annoying to play against. Do we need to implement some discounting?
-	private Move pickRandomBestMove(MoveAndValue[] scoredMoves){
-		Arrays.sort(scoredMoves, Collections.reverseOrder());
-		int bestScore = scoredMoves[0].value;
-
-		// count the number of moves tied for top score
-		int numMovesWithHighScore = 1;
-		while(numMovesWithHighScore < scoredMoves.length && bestScore == scoredMoves[numMovesWithHighScore].value){
-			numMovesWithHighScore++;
-		}
-
-		// pick a random move from the moves tied for the highest score
-		int randomHighScoringMoveIndex = (int) Math.floor(Math.random() * (double) numMovesWithHighScore);
-		return scoredMoves[randomHighScoringMoveIndex].move;
 	}
 
 	// color keeps track of the player. It is 1 if we are the player, -1 if the
@@ -104,30 +104,86 @@ public class NegaMaxAgent implements Agent {
 
 			// these three lines make a move, recurivsely call the negamax on the new board
 			// state, and then un-make the move. This allows us to get the value of the move
-			// without
-			// "making" the move on our actual board
+			// without "making" the move on our actual board
 			simulationBoard.makeMove(possibleMove);
 			int negaMax_value = -negaMax(simulationBoard, currentDepth + 1, depthCount, -beta, -alpha, -color);
 			simulationBoard.undoLastMove();
+
+			// Check if the Agent has more time to think. If it does not, return immediately.
+			if(atTimeout()){
+				// Return a neutral move score
+				// The score doesn't actually matter since we don't factor it into our move choice if we time out mid level
+				return 0;
+			}
 
 			// if we found a move better than our max, it is our new max
 			if (negaMax_value > max) {
 				max = negaMax_value;
 			}
 
-			// Setting the bounds for our pruning
+			// Update the bounds for our pruning
 			if (negaMax_value > alpha) {
 				alpha = negaMax_value;
 			}
 
 			// if the move we are looking at has a value greater than the worst move the
-			// opponent can make us take, we prune
+			// opponent can make us take, we stop looking at this branch since there's no way we could end up here
 			if (negaMax_value > beta) {
-				return negaMax_value; // TODO: I think this is the right value to retun here, but I'm not positive. Need to double check what we should return during pruning.
+				return negaMax_value;
 			}
 
 		}
-
 		return max;
+	}
+
+	// ========== HELPERS ==========
+
+	// If a number of moves are tied with the highest score, pick a random one so that the bot varies its play
+	// TODO: this will lead to the behavior that if the CPU has a guaranteed win, it will make random moves instead of immediately winning.
+	// 	Should be fine functionally, but might be annoying to play against. Do we need to implement some discounting?
+	private Move pickRandomBestMove(MoveAndValue[] scoredMoves){
+		Arrays.sort(scoredMoves, Collections.reverseOrder());
+		int bestScore = scoredMoves[0].value;
+
+		// count the number of moves tied for top score
+		int numMovesWithHighScore = 1;
+		while(numMovesWithHighScore < scoredMoves.length && bestScore == scoredMoves[numMovesWithHighScore].value){
+			numMovesWithHighScore++;
+		}
+
+		// pick a random move from the moves tied for the highest score
+		int randomHighScoringMoveIndex = (int) Math.floor(Math.random() * (double) numMovesWithHighScore);
+		return scoredMoves[randomHighScoringMoveIndex].move;
+	}
+
+	/*
+	 * Return the best Move the Agent has found after completing a full layer of analysis.
+	 * Moves are sorted after each layer is completed, so the first move is always the best we've found so far
+	 */
+	private Move bestMoveSoFar(MoveAndValue[] sortedScoredMoves){
+		return sortedScoredMoves[0].move;
+	}
+
+	/*
+	 * Returns true if the Agent is out of time to think and must return its move choice.
+	 * Returns false if the agent has more time to think.
+	 */
+	private boolean atTimeout(){
+		// If the Agent's timeout is negative, it has no timeout and can think forever
+		if(this.thinkTimeMs < 0){
+			return false;
+		}
+		// If it has a timeout, return true if the current timestamp has exceeded the limit
+		return System.currentTimeMillis() > this.timeLimit;
+	}
+
+	/*
+	 * Set the timeout for this round of move selection.
+	 * If there is a think-time limit of N, set the timeout as N ms after the current timestamp
+	 */
+	private void setTimeout() {
+		if(this.thinkTimeMs >= 0){
+			this.timeLimit = System.currentTimeMillis() + thinkTimeMs;
+		}
 	}
 }

--- a/src/main/java/com/jherrick/NegaMaxAgent.java
+++ b/src/main/java/com/jherrick/NegaMaxAgent.java
@@ -1,5 +1,6 @@
 package com.jherrick;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Arrays;
 
@@ -57,7 +58,7 @@ public class NegaMaxAgent implements Agent {
 			}
 			iterativeMaxDepth++;
 			// explore the best moves first
-			Arrays.sort(moves);
+			Arrays.sort(moves, Collections.reverseOrder());
 		}
 
 //		return moves[0].move;
@@ -68,7 +69,7 @@ public class NegaMaxAgent implements Agent {
 	// TODO: this will lead to the behavior that if the CPU has a guaranteed win, it will make random moves instead of immediately winning.
 	// 	Should be fine functionally, but might be annoying to play against. Do we need to implement some discounting?
 	private Move pickRandomBestMove(MoveAndValue[] scoredMoves){
-		Arrays.sort(scoredMoves);
+		Arrays.sort(scoredMoves, Collections.reverseOrder());
 		int bestScore = scoredMoves[0].value;
 
 		// count the number of moves tied for top score

--- a/src/test/java/com/jherrick/BoardGeneratorOnDemand.java
+++ b/src/test/java/com/jherrick/BoardGeneratorOnDemand.java
@@ -7,9 +7,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import com.jherrick.Utils;
-
-public class TestBoardGenerator {
+public class BoardGeneratorOnDemand {
 	
 	/**
 	 * Randomly generate boards from the Utils.generateRandomBoard() function, and saves to file.

--- a/src/test/java/com/jherrick/HCNTest.java
+++ b/src/test/java/com/jherrick/HCNTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
  * functions include: boardToHCN(), subBoardToHCN(), and Board's HCN
  * constructor.
  */
-class TestHCN {
+class HCNTest {
 
 	/**
 	 * We create a board from HCN, convert that board to an HCN, and assert they are

--- a/src/test/java/com/jherrick/MoveGenerationTest.java
+++ b/src/test/java/com/jherrick/MoveGenerationTest.java
@@ -13,13 +13,13 @@ import org.junit.jupiter.api.Test;
  * Test class to confirm move generation works as expected. Tests both on random
  * positions confirming expected number of positions, and predetermined boards.
  */
-class TestMoveGeneration {
+class MoveGenerationTest {
 
 	/**
 	 * We use the randomly generated positions to confirm that we have the expected
 	 * number of moves.
 	 * 
-	 * @throws IOExceptiont
+	 * @throws IOException
 	 */
 	@DisplayName("Move Generation Shallow Test")
 	@Test

--- a/src/test/java/com/jherrick/NegaMaxAgentOnDemand.java
+++ b/src/test/java/com/jherrick/NegaMaxAgentOnDemand.java
@@ -12,6 +12,13 @@ public class NegaMaxAgentOnDemand {
         Side agentSide = Side.X;
         return new NegaMaxAgent(evaluator, agentSide);
     }
+
+    public static NegaMaxAgent createXNegamaxAgentWithTimeout(long thinkTime){
+        BoardEvaluator evaluator = new BasicBoardEvaluator();
+        Side agentSide = Side.X;
+        return new NegaMaxAgent(evaluator, agentSide, thinkTime);
+    }
+
     @Test
     public void given_ImmediateWinningMoveAvailable_when_PickingMove_then_ReturnWinningMove(){
         // Arrange
@@ -71,6 +78,21 @@ public class NegaMaxAgentOnDemand {
 
     // Evaluate to deeper win conditions and make sure it can find them
 
+    @Test
+    public void timeoutTest(){
+        // Arrange
+        long thinkTime = 15L;
+        NegaMaxAgent xAgent = createXNegamaxAgentWithTimeout(thinkTime);
+        Board board = new BigBoard("XOXXOOO2/X8/OOO6/X8/X8/OOO6/X8/XX1OOXXXO/OO1XXOX1X X g9");
+        long start = System.currentTimeMillis();
+
+        // Act
+        xAgent.pickMove(board);
+
+        // Assert
+        long delta = System.currentTimeMillis() - start;
+        Assertions.assertTrue(delta < thinkTime + 5);
+    }
     @Test
     public void moveUtilsTest(){
         System.out.println(new BigBoard());

--- a/src/test/java/com/jherrick/NegaMaxAgentOnDemand.java
+++ b/src/test/java/com/jherrick/NegaMaxAgentOnDemand.java
@@ -1,0 +1,86 @@
+package com.jherrick;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class NegaMaxAgentOnDemand {
+    public static NegaMaxAgent createXNegamaxAgent(){
+        BoardEvaluator evaluator = new BasicBoardEvaluator();
+        Side agentSide = Side.X;
+        return new NegaMaxAgent(evaluator, agentSide);
+    }
+    @Test
+    public void given_ImmediateWinningMoveAvailable_when_PickingMove_then_ReturnWinningMove(){
+        // Arrange
+        NegaMaxAgent xAgent = createXNegamaxAgent();
+        String startingPosition = "1XX6/OOO6/OOO6/XXX6/OOO6/OOO6/XXX6/OO1OO4/OO1OO4 X g9"; // A board with an available move for X to win the game in one move: a9. All other moves will lose immediately
+        Board boardWithImmediateWinningMove = new BigBoard(startingPosition);
+        System.out.println(boardWithImmediateWinningMove);
+        Move winningMove = new Move(Constants.BIT_MASKS[0],0);
+        System.out.println(winningMove.toString());
+
+        // Act
+        Move selectedMove = xAgent.pickMove(boardWithImmediateWinningMove);
+        System.out.println("Selected Move: " + selectedMove);
+
+        // Assert
+        Assertions.assertEquals(winningMove.toString(), selectedMove.toString());
+    }
+
+    @Test
+    public void given_MultipleIdenticalScoringMoves_when_PickingMove_then_PickARandomOne(){
+        // Arrange
+        NegaMaxAgent xAgent = createXNegamaxAgent();
+        String startingPosition = "XX4XX1/OOO6/OOO6/XXX6/OO1OO4/OO1OO4/XXX6/OO1OO4/OO1OO4 X g9"; // X has multiple winning moves available, each trial should pick a different one
+        Board boardWithImmediateWinningMove = new BigBoard(startingPosition);
+        List<String> winningMoves = Arrays.asList("c9", "a8", "b8", "c7");
+        System.out.println(boardWithImmediateWinningMove);
+
+        // Act
+        Move selectedMove = xAgent.pickMove(boardWithImmediateWinningMove);
+        System.out.println("Selected Move: " + selectedMove);
+
+        // Assert
+        // It should return one of c9, a8, b8, or c7. Should not return c8.
+        Assertions.assertTrue(winningMoves.contains(selectedMove.toString()));
+    }
+
+    // Test that we are expecting O to minimize correctly - makes their best immediate move
+    @Test
+    public void given_OHasGoodMoveAvailable_when_PickingMove_then_WeAssumeTheyTakeIt(){
+        // Arrange
+        NegaMaxAgent xAgent = createXNegamaxAgent();
+        // c7 leads to a sub board where O can win if they make the right move, but X will win if not.
+        // b7 leads to a normal in-progress game.
+        // we should pick b7
+        String startingPosition = "XOXXOOO2/X8/OOO6/X8/X8/OOO6/X8/XX1OOXXXO/OO1XXOX1X X g9";
+        Board boardWithImmediateWinningMove = new BigBoard(startingPosition);
+        System.out.println(boardWithImmediateWinningMove);
+        String bestMove = "b7";
+
+        // Act
+        Move selectedMove = xAgent.pickMove(boardWithImmediateWinningMove);
+        System.out.println("Selected Move: " + selectedMove);
+
+        // Assert
+        Assertions.assertEquals(bestMove, selectedMove.toString());
+    }
+
+    // Evaluate to deeper win conditions and make sure it can find them
+
+    @Test
+    public void moveUtilsTest(){
+        System.out.println(new BigBoard());
+        for(int board = 0; board < 9; board++){
+            for(int move = 0; move < 9; move++){
+                Move m = new Move(Constants.BIT_MASKS[move], board);
+                System.out.println(m);
+            }
+            System.out.println();
+        }
+    }
+}
+

--- a/src/test/java/com/jherrick/TestUtils.java
+++ b/src/test/java/com/jherrick/TestUtils.java
@@ -20,7 +20,9 @@ public final class TestUtils {
 		}
 		for(int i = 0; i < b.boards.length; i++) {
 			if(m == null || ((m.move & Constants.BIT_MASKS[i]) > 0) || b.boards[target].getState() != BoardState.IN_PROGRESS) {
-				count += Integer.bitCount(b.boards[i].generateMoves());
+				if(b.boards[i].getState() == BoardState.IN_PROGRESS) {
+					count += Integer.bitCount(b.boards[i].generateMoves());
+				}
 			}
 		}
 		return count;


### PR DESCRIPTION
* Fix the first level of Negamax to min instead of max (since we are manually maxing at the first level)
* Update board impl to reset game state (like X_WON) when moves are taken back
* Update the pruning to return the negamax value 
* Reset maxValue in between rounds of iterative deepening - if we see a great move at depth 1 that turns out to not be great, we shouldn't keep pruning as if it's great. 
* Update max values to avoid int overflow issues during sign flipping 
* Fix MoveAndValue comparator to avoid integer overflow issues
* Fix NegaMaxAgent iterative deepening process to order the moves correctly 
* Add optional timeout to negamax agent 